### PR TITLE
fix: update style to remove scrollbars 🖱️

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -7,7 +7,7 @@
 }
 
 body {
-  margin: 2px;
+  margin: 0;
   overscroll-behavior: none;
   background-color: black;
   color: white;

--- a/styles/editor.module.scss
+++ b/styles/editor.module.scss
@@ -4,6 +4,7 @@ $spacing: 20px;
   height: calc(100vh - 10px);
   position: relative;
   font-family: 'Press Start 2P', cursive;
+  overflow: hidden;
 
   .editor {
     opacity: 0.7;


### PR DESCRIPTION
There was two problems : 

## Editor flashing
➡️ The editor was flashing with my 13" mac, it is resizing it's width every time a new letter is typed, not sure why but the `overflow: hidden` should do the trick
#### The bug
https://github.com/CruuzAzul/code-in-the-dark/assets/25451288/a624439d-3de2-4ffa-b1cb-48d4fea18f05
#### The correction
https://github.com/CruuzAzul/code-in-the-dark/assets/25451288/35140c33-86c9-4cbb-b8d8-9f34b3ccdbf3

## Result scrollbar
➡️  There was a scrollbar for the result page, i just deleted the margin from the body because it didn't seems necessary
#### The bug
<img width="1440" alt="Screenshot 2024-03-20 at 13 17 51" src="https://github.com/CruuzAzul/code-in-the-dark/assets/25451288/440480fc-ccab-4fac-9b23-1d062729b773">
#### The correction
<img width="1440" alt="Screenshot 2024-03-20 at 13 25 20" src="https://github.com/CruuzAzul/code-in-the-dark/assets/25451288/1b18593a-479c-44a6-84e1-d9f37b2233a9">
